### PR TITLE
Make `automeme` multi-channel, add `automeme_cancel` command

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -577,6 +577,16 @@ async def automeme(ctx):
         automeme_loops[channel_id] = loop
         loop.start(ctx)
 
+@client.command()
+async def automeme_cancel(ctx):
+    '''Cancel the Automeme task in the current channel'''
+    channel_id = ctx.channel.id
+    if channel_id not in automeme_loops:
+        await ctx.send('Automeme not running here')
+    else:
+        automeme_loops[channel_id].cancel()
+        del automeme_loops[channel_id]
+        await ctx.send('Automeme canceled here')
 
 async def automeme_routine(ctx):
     '''

--- a/bot/main.py
+++ b/bot/main.py
@@ -45,6 +45,9 @@ timecheck = 0
 buls = 0
 ssl._create_default_https_context = ssl._create_unverified_context
 
+# Map of channel IDs to tasks.Loop automeme loops
+automeme_loops = {}
+
 # intents (new discord feature to limit bots to certain bucket events)
 intents = discord.Intents.default()
 intents.typing = False
@@ -562,14 +565,19 @@ async def memes(ctx):
         await ctx.send(embed=embed)
 
 
-# ---> NEEDS FIXING <---
 @client.command()
 async def automeme(ctx):
     '''Triggers the automeme taskloop for the channel context'''
-    automeme_routine.start(ctx)
+    channel_id = ctx.channel.id
+    if channel_id in automeme_loops:
+        await ctx.send('Automeme already running here')
+    else:
+        # using decorator instead of tasks.Loop directly to preserve default arguments
+        loop = tasks.loop(seconds=600)(automeme_routine)
+        automeme_loops[channel_id] = loop
+        loop.start(ctx)
 
 
-@tasks.loop(seconds=600)
 async def automeme_routine(ctx):
     '''
     sends a meme every 10 mins


### PR DESCRIPTION
Adds the ability for the `automeme` command to be used once per channel, instead of once per bot instance - fixes #6 

Adds the `automeme_cancel` command, which will cancel the `automeme` Loop task for the current channel - resolves #18 