### PR TITLE
feat(150): Avatar command

### DIFF
--- a/bot/cogs/users_cog.py
+++ b/bot/cogs/users_cog.py
@@ -1,18 +1,20 @@
 import discord
-from discord import commands
+from discord.ext import commands
 
 class Users(commands.Cog):
     def __init__(self, client):
         self.client = client
 
     @commands.command(pass_context=True)
-    async def user(self, ctx, user: discord.Member):
+    async def user(self, ctx, *, user: discord.Member = None):
         '''gives user info'''
+        if user is None:
+            user = ctx.message.author
         embed = discord.Embed(
             title="{}'s info".format(
                 user.name),
             description="Here's what I could find.",
-            color=0x00ff00)
+            color=user.color)
         embed.add_field(name="Name", value=user.name, inline=True)
         embed.add_field(name="ID", value=user.id, inline=True)
         embed.add_field(name="Status", value=user.status, inline=True)
@@ -22,8 +24,15 @@ class Users(commands.Cog):
         embed.set_thumbnail(url=user.avatar_url)
         await ctx.send(embed=embed)
 
-    @command.command(pass_context=True)
-    async def avatar(self, ctx, user:discor.Member)
+    @commands.command(pass_context=True)
+    async def avatar(self, ctx, *, user: discord.Member = None):
+        if user is None:
+            user = ctx.message.author
+        async with ctx.channel.typing():
+            embed = discord.Embed(color=user.color)
+            embed.set_footer(text=f"Displaying avatar of {user.display_name}")
+            embed.set_image(url=user.avatar_url)
+        await ctx.send(embed=embed)
 
 def setup(client):
-    client.add_cog(Utils(client))
+    client.add_cog(Users(client))

--- a/bot/cogs/users_cog.py
+++ b/bot/cogs/users_cog.py
@@ -1,0 +1,29 @@
+import discord
+from discord import commands
+
+class Users(commands.Cog):
+    def __init__(self, client):
+        self.client = client
+
+    @commands.command(pass_context=True)
+    async def user(self, ctx, user: discord.Member):
+        '''gives user info'''
+        embed = discord.Embed(
+            title="{}'s info".format(
+                user.name),
+            description="Here's what I could find.",
+            color=0x00ff00)
+        embed.add_field(name="Name", value=user.name, inline=True)
+        embed.add_field(name="ID", value=user.id, inline=True)
+        embed.add_field(name="Status", value=user.status, inline=True)
+        embed.add_field(name="Highest role", value=user.top_role)
+        embed.add_field(name="Joined", value=user.joined_at)
+        embed.add_field(name='Account Created on', value=user.created_at)
+        embed.set_thumbnail(url=user.avatar_url)
+        await ctx.send(embed=embed)
+
+    @command.command(pass_context=True)
+    async def avatar(self, ctx, user:discor.Member)
+
+def setup(client):
+    client.add_cog(Utils(client))

--- a/bot/cogs/utils_cog.py
+++ b/bot/cogs/utils_cog.py
@@ -47,22 +47,6 @@ class Utils(commands.Cog):
         output = '%20'.join(args)
         await ctx.send(baseurl + output)
 
-    @commands.command(pass_context=True)
-    async def user(self, ctx, user: discord.Member):
-        '''gives user info'''
-        embed = discord.Embed(
-            title="{}'s info".format(
-                user.name),
-            description="Here's what I could find.",
-            color=0x00ff00)
-        embed.add_field(name="Name", value=user.name, inline=True)
-        embed.add_field(name="ID", value=user.id, inline=True)
-        embed.add_field(name="Status", value=user.status, inline=True)
-        embed.add_field(name="Highest role", value=user.top_role)
-        embed.add_field(name="Joined", value=user.joined_at)
-        embed.add_field(name='Account Created on', value=user.created_at)
-        embed.set_thumbnail(url=user.avatar_url)
-        await ctx.send(embed=embed)
 
     @commands.command(pass_context=True)
     async def wiki(self, ctx, *, args):

--- a/bot/main.py
+++ b/bot/main.py
@@ -41,6 +41,7 @@ ls_cog = ['cogs.fun_cog',
           'cogs.economy_cog',
           'cogs.events_cog',
           'cogs.error_cog',
+          'cogs.users_cog',
           'jishaku']
 
 


### PR DESCRIPTION
Added an `avatar` command to the bot.
Also tweaked user-info, to show user colour in the embed.
#### Usage- 
`qq avatar <discord.Member object>`
#### Additional Context-
![Screenshot 2020-11-25 at 8 09 14 PM](https://user-images.githubusercontent.com/62864373/100241796-1cb33200-2f5a-11eb-876a-cd6a3d5c2053.png)
