### PR TITLE
feat: added xkcd command

### DIFF
--- a/bot/cogs/comic_cog.py
+++ b/bot/cogs/comic_cog.py
@@ -1,0 +1,36 @@
+from random import randint
+
+import discord
+from discord.ext import commands
+from typing import Optional
+import aiohttp
+
+class Comics(commands.Cog):
+    def __init__(self, client):
+        self.client = client
+
+    @commands.command()
+    async def xkcd(self, ctx, arg: Optional[str]='random'):
+        '''Provides a comic strip from xkcd blog'''
+        base_url = 'https://xkcd.com/'
+        if arg == 'random':
+            base_url += f'{randint(1, 2390)}/'
+        elif arg == 'latest':
+            pass
+        else:
+            base_url += f'{arg}/'
+        async with aiohttp.ClientSession() as session:
+            url = base_url + 'info.0.json'
+            async with session.get(url) as json:
+                json = await json.json()
+            embed = discord.Embed(title=json['title'],
+                                  url=base_url,
+                                  description=json['alt'],
+                                  color=0x96a8c8)
+            embed.set_image(url=json['img'])
+            txt = f"xkcd comic #{json['num']} | Requested by {ctx.author.name}"
+            embed.set_footer(text=txt)
+        await ctx.send(embed=embed)
+
+def setup(client):
+    client.add_cog(Comics(client))

--- a/bot/cogs/comic_cog.py
+++ b/bot/cogs/comic_cog.py
@@ -1,9 +1,9 @@
 from random import randint
+from typing import Optional
+import aiohttp
 
 import discord
 from discord.ext import commands
-from typing import Optional
-import aiohttp
 
 class Comics(commands.Cog):
     def __init__(self, client):

--- a/bot/main.py
+++ b/bot/main.py
@@ -39,6 +39,7 @@ ls_cog = ['cogs.fun_cog',
           'cogs.events_cog',
           'cogs.error_cog',
           'cogs.users_cog',
+          'cogs.comic_cog',
           'jishaku']
 
 


### PR DESCRIPTION
This adds a new cog **Comic** indexed via 'cogs.comic_cog'
The first command added to this cog is the `xkcd` command, which sends an embed, containing a comic strip from [xkcd comic strip](https://xkcd.com)

![Screenshot 2020-12-01 at 12 46 38 PM](https://user-images.githubusercontent.com/62864373/100710263-7772e080-33d5-11eb-8d25-4d5a84a1aeec.png)

Issue: not opened, but referred in note: https://github.com/Vyvy-vi/TearDrops/projects/2#card-50367318